### PR TITLE
Add Ascii object for control characters and extension methods

### DIFF
--- a/core/jvm/src/main/scala/terminus/Prompt.scala
+++ b/core/jvm/src/main/scala/terminus/Prompt.scala
@@ -16,7 +16,7 @@
 
 package terminus
 
-import terminus.effect.Eof
+import terminus.effect.{Ascii, Eof}
 
 enum KeyCode {
   case Down
@@ -52,8 +52,8 @@ def read(): Program[KeyCode] = {
       throw new Exception("Received an EOF")
     case char: Char =>
       char match {
-        case 10 | 13 => KeyCode.Enter
-        case '\u001b' =>
+        case Ascii.LF | Ascii.CR => KeyCode.Enter
+        case Ascii.ESC =>
           Terminal.read() match {
             // Normal mode
             case '[' =>

--- a/core/native/src/main/scala/terminus/Prompt.scala
+++ b/core/native/src/main/scala/terminus/Prompt.scala
@@ -16,7 +16,7 @@
 
 package terminus
 
-import terminus.effect.Eof
+import terminus.effect.{Ascii, Eof}
 
 enum KeyCode {
   case Down
@@ -52,8 +52,8 @@ def read(): Program[KeyCode] = {
       throw new Exception("Received an EOF")
     case char: Char =>
       char match {
-        case 10 | 13 => KeyCode.Enter
-        case '\u001b' =>
+        case Ascii.LF | Ascii.CR => KeyCode.Enter
+        case Ascii.ESC =>
           Terminal.read() match {
             // Normal mode
             case '[' =>

--- a/core/shared/src/main/scala/terminus/effect/AnsiCodes.scala
+++ b/core/shared/src/main/scala/terminus/effect/AnsiCodes.scala
@@ -25,14 +25,12 @@ package terminus.effect
   *   - https://ghostty.org/docs/vt
   */
 object AnsiCodes {
-
-  /** The escape character, which all codes begin with. */
-  val esc: Char = '\u001b'
+  import Ascii.*
 
   /** The Control Sequencer Introducer code, which starts many escape codes. It
     * is ESC[
     */
-  val csiCode: String = s"${esc}["
+  val csiCode: String = s"${ESC}["
 
   /** Create a CSI escape code. The terminator must be specifed first, followed
     * by zero or more arguments. The arguments will printed semi-colon separated
@@ -55,30 +53,30 @@ object AnsiCodes {
       * if no state has been saved.
       */
     val restore: String =
-      s"${esc}8"
+      s"${ESC}8"
 
     /** Save the cursor location, character set, pending wrap state, SGR
       * attributes, and origin mode.
       */
     val save: String =
-      s"${esc}7"
+      s"${ESC}7"
 
     object style {
-      val default = s"${esc}0 q"
+      val default = s"${ESC}0 q"
 
       object block {
-        val blink = s"${esc}1 q"
-        val steady = s"${esc}2 q"
+        val blink = s"${ESC}1 q"
+        val steady = s"${ESC}2 q"
       }
 
       object underline {
-        val blink = s"${esc}3 q"
-        val steady = s"${esc}4 q"
+        val blink = s"${ESC}3 q"
+        val steady = s"${ESC}4 q"
       }
 
       object bar {
-        val blink = s"${esc}5 q"
-        val steady = s"${esc}6 q"
+        val blink = s"${ESC}5 q"
+        val steady = s"${ESC}6 q"
       }
     }
 

--- a/core/shared/src/main/scala/terminus/effect/Ascii.scala
+++ b/core/shared/src/main/scala/terminus/effect/Ascii.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package terminus.effect
 
 /** Ascii character codes and Ascii related extension methods. See:

--- a/core/shared/src/main/scala/terminus/effect/Ascii.scala
+++ b/core/shared/src/main/scala/terminus/effect/Ascii.scala
@@ -4,100 +4,100 @@ package terminus.effect
   * https://www.ascii-code.com/
   */
 object Ascii {
-  
+
   /** Null character */
   val NUL: Char = '\u0000'
-  
+
   /** Start of Heading */
   val SOH: Char = '\u0001'
-  
+
   /** Start of Text */
   val STX: Char = '\u0002'
-  
+
   /** End of Text */
   val ETX: Char = '\u0003'
-  
+
   /** End of Transmission */
   val EOT: Char = '\u0004'
-  
+
   /** Enquiry */
   val ENQ: Char = '\u0005'
-  
+
   /** Acknowledge */
   val ACK: Char = '\u0006'
-  
+
   /** Bell, Alert */
   val BEL: Char = '\u0007'
-  
+
   /** Backspace */
   val BS: Char = '\u0008'
-  
-  /** Horizontal Tab */
+
+  /** Horizontal Tab - also \t */
   val HT: Char = '\u0009'
-  
-  /** Line Feed */
+
+  /** Line Feed - also \n */
   val LF: Char = '\u000A'
-  
+
   /** Vertical Tabulation */
   val VT: Char = '\u000B'
-  
+
   /** Form Feed */
   val FF: Char = '\u000C'
-  
-  /** Carriage Return */
+
+  /** Carriage Return - also \r */
   val CR: Char = '\u000D'
-  
+
   /** Shift Out */
   val SO: Char = '\u000E'
-  
+
   /** Shift In */
   val SI: Char = '\u000F'
-  
+
   /** Data Link Escape */
   val DLE: Char = '\u0010'
-  
+
   /** Device Control One (XON) */
   val DC1: Char = '\u0011'
-  
+
   /** Device Control Two */
   val DC2: Char = '\u0012'
-  
+
   /** Device Control Three (XOFF) */
   val DC3: Char = '\u0013'
-  
+
   /** Device Control Four */
   val DC4: Char = '\u0014'
-  
+
   /** Negative Acknowledge */
   val NAK: Char = '\u0015'
-  
+
   /** Synchronous Idle */
   val SYN: Char = '\u0016'
-  
+
   /** End of Transmission Block */
   val ETB: Char = '\u0017'
-  
+
   /** Cancel */
   val CAN: Char = '\u0018'
-  
+
   /** End of medium */
   val EM: Char = '\u0019'
-  
+
   /** Substitute */
   val SUB: Char = '\u001A'
-  
+
   /** Escape */
   val ESC: Char = '\u001B'
-  
+
   /** File Separator */
   val FS: Char = '\u001C'
-  
+
   /** Group Separator */
   val GS: Char = '\u001D'
-  
+
   /** Record Separator */
   val RS: Char = '\u001E'
-  
+
   /** Unit Separator */
   val US: Char = '\u001F'
 
@@ -105,6 +105,21 @@ object Ascii {
   val DEL: Char = '\u007F'
 
   extension (char: Char)
-    def isControl: Boolean = char >= 0x00 && char < 0x20
-    def isPrintable: Boolean = char >= 0x20 && char != DEL
+    /** Evaluates as true if the character is an Ascii control character,
+      * otherwise false.
+      */
+    def isControlChar: Boolean = char >= 0x00 && char < 0x20
+
+    /** Evaluates as true if the character is not an Ascii control character
+     * or DEL otherwise false.
+     *
+     * While DEL can be considered an ascii-printable character, an end user
+     * is likely to want to treat a DEL input separate from other keystrokes,
+     * as the character can be displayed like this:
+     * {{{
+     * scala> println(s"Foo${Ascii.DEL}bar")
+     * Foo bar
+     * }}}
+     */
+    def isPrintableChar: Boolean = char >= 0x20 && char != DEL
 }

--- a/core/shared/src/main/scala/terminus/effect/Ascii.scala
+++ b/core/shared/src/main/scala/terminus/effect/Ascii.scala
@@ -1,0 +1,110 @@
+package terminus.effect
+
+/** Ascii character codes and Ascii related extension methods. See:
+  * https://www.ascii-code.com/
+  */
+object Ascii {
+  
+  /** Null character */
+  val NUL: Char = '\u0000'
+  
+  /** Start of Heading */
+  val SOH: Char = '\u0001'
+  
+  /** Start of Text */
+  val STX: Char = '\u0002'
+  
+  /** End of Text */
+  val ETX: Char = '\u0003'
+  
+  /** End of Transmission */
+  val EOT: Char = '\u0004'
+  
+  /** Enquiry */
+  val ENQ: Char = '\u0005'
+  
+  /** Acknowledge */
+  val ACK: Char = '\u0006'
+  
+  /** Bell, Alert */
+  val BEL: Char = '\u0007'
+  
+  /** Backspace */
+  val BS: Char = '\u0008'
+  
+  /** Horizontal Tab */
+  val HT: Char = '\u0009'
+  
+  /** Line Feed */
+  val LF: Char = '\u000A'
+  
+  /** Vertical Tabulation */
+  val VT: Char = '\u000B'
+  
+  /** Form Feed */
+  val FF: Char = '\u000C'
+  
+  /** Carriage Return */
+  val CR: Char = '\u000D'
+  
+  /** Shift Out */
+  val SO: Char = '\u000E'
+  
+  /** Shift In */
+  val SI: Char = '\u000F'
+  
+  /** Data Link Escape */
+  val DLE: Char = '\u0010'
+  
+  /** Device Control One (XON) */
+  val DC1: Char = '\u0011'
+  
+  /** Device Control Two */
+  val DC2: Char = '\u0012'
+  
+  /** Device Control Three (XOFF) */
+  val DC3: Char = '\u0013'
+  
+  /** Device Control Four */
+  val DC4: Char = '\u0014'
+  
+  /** Negative Acknowledge */
+  val NAK: Char = '\u0015'
+  
+  /** Synchronous Idle */
+  val SYN: Char = '\u0016'
+  
+  /** End of Transmission Block */
+  val ETB: Char = '\u0017'
+  
+  /** Cancel */
+  val CAN: Char = '\u0018'
+  
+  /** End of medium */
+  val EM: Char = '\u0019'
+  
+  /** Substitute */
+  val SUB: Char = '\u001A'
+  
+  /** Escape */
+  val ESC: Char = '\u001B'
+  
+  /** File Separator */
+  val FS: Char = '\u001C'
+  
+  /** Group Separator */
+  val GS: Char = '\u001D'
+  
+  /** Record Separator */
+  val RS: Char = '\u001E'
+  
+  /** Unit Separator */
+  val US: Char = '\u001F'
+
+  /** Delete */
+  val DEL: Char = '\u007F'
+
+  extension (char: Char)
+    def isControl: Boolean = char >= 0x00 && char < 0x20
+    def isPrintable: Boolean = char >= 0x20 && char != DEL
+}

--- a/core/shared/src/test/scala/terminus/effect/AnsiCodesSuite.scala
+++ b/core/shared/src/test/scala/terminus/effect/AnsiCodesSuite.scala
@@ -19,10 +19,6 @@ package terminus.effect
 import munit.FunSuite
 
 class AnsiCodesSuite extends FunSuite {
-  test("esc is the correct character") {
-    assertEquals(AnsiCodes.esc, '\u001b')
-  }
-
   test("csi is the correct code") {
     assertEquals(AnsiCodes.csiCode, "[")
   }

--- a/core/shared/src/test/scala/terminus/effect/AsciiSuite.scala
+++ b/core/shared/src/test/scala/terminus/effect/AsciiSuite.scala
@@ -1,0 +1,105 @@
+package terminus.effect
+
+import munit.FunSuite
+
+class AsciiSuite extends FunSuite {
+  import Ascii.*
+
+  test("String escape characters match their Ascii characters") {
+    assertEquals(HT, '\t')
+    assertEquals(LF, '\n')
+    assertEquals(CR, '\r')
+  }
+
+  test("Ascii control characters are identified correctly") {
+    assertEquals(NUL.isControlChar, true)
+    assertEquals(SOH.isControlChar, true)
+    assertEquals(STX.isControlChar, true)
+    assertEquals(ETX.isControlChar, true)
+    assertEquals(EOT.isControlChar, true)
+    assertEquals(ENQ.isControlChar, true)
+    assertEquals(ACK.isControlChar, true)
+    assertEquals(BEL.isControlChar, true)
+    assertEquals(BS.isControlChar, true)
+    assertEquals(HT.isControlChar, true)
+    assertEquals(LF.isControlChar, true)
+    assertEquals(VT.isControlChar, true)
+    assertEquals(FF.isControlChar, true)
+    assertEquals(CR.isControlChar, true)
+    assertEquals(SO.isControlChar, true)
+    assertEquals(SI.isControlChar, true)
+    assertEquals(DLE.isControlChar, true)
+    assertEquals(DC1.isControlChar, true)
+    assertEquals(DC2.isControlChar, true)
+    assertEquals(DC3.isControlChar, true)
+    assertEquals(DC4.isControlChar, true)
+    assertEquals(NAK.isControlChar, true)
+    assertEquals(SYN.isControlChar, true)
+    assertEquals(ETB.isControlChar, true)
+    assertEquals(CAN.isControlChar, true)
+    assertEquals(EM.isControlChar, true)
+    assertEquals(SUB.isControlChar, true)
+    assertEquals(ESC.isControlChar, true)
+    assertEquals(FS.isControlChar, true)
+    assertEquals(GS.isControlChar, true)
+    assertEquals(RS.isControlChar, true)
+    assertEquals(US.isControlChar, true)
+  }
+
+  test("Non-control characters are not identified as control characters") {
+    assertEquals(DEL.isControlChar, false)
+    assertEquals('a'.isControlChar, false)
+    assertEquals('A'.isControlChar, false)
+    assertEquals('1'.isControlChar, false)
+    assertEquals('@'.isControlChar, false)
+    assertEquals('Þ'.isControlChar, false)
+    assertEquals('な'.isControlChar, false)
+    assertEquals('私'.isControlChar, false)
+  }
+
+  test("Regular characters are identified as printable") {
+    assertEquals('a'.isPrintableChar, true)
+    assertEquals('A'.isPrintableChar, true)
+    assertEquals('1'.isPrintableChar, true)
+    assertEquals('@'.isPrintableChar, true)
+    assertEquals('Þ'.isPrintableChar, true)
+    assertEquals('な'.isPrintableChar, true)
+    assertEquals('私'.isPrintableChar, true)
+  }
+
+  test("Control characters and DEL are not identified as printable") {
+    assertEquals(NUL.isPrintableChar, false)
+    assertEquals(SOH.isPrintableChar, false)
+    assertEquals(STX.isPrintableChar, false)
+    assertEquals(ETX.isPrintableChar, false)
+    assertEquals(EOT.isPrintableChar, false)
+    assertEquals(ENQ.isPrintableChar, false)
+    assertEquals(ACK.isPrintableChar, false)
+    assertEquals(BEL.isPrintableChar, false)
+    assertEquals(BS.isPrintableChar, false)
+    assertEquals(HT.isPrintableChar, false)
+    assertEquals(LF.isPrintableChar, false)
+    assertEquals(VT.isPrintableChar, false)
+    assertEquals(FF.isPrintableChar, false)
+    assertEquals(CR.isPrintableChar, false)
+    assertEquals(SO.isPrintableChar, false)
+    assertEquals(SI.isPrintableChar, false)
+    assertEquals(DLE.isPrintableChar, false)
+    assertEquals(DC1.isPrintableChar, false)
+    assertEquals(DC2.isPrintableChar, false)
+    assertEquals(DC3.isPrintableChar, false)
+    assertEquals(DC4.isPrintableChar, false)
+    assertEquals(NAK.isPrintableChar, false)
+    assertEquals(SYN.isPrintableChar, false)
+    assertEquals(ETB.isPrintableChar, false)
+    assertEquals(CAN.isPrintableChar, false)
+    assertEquals(EM.isPrintableChar, false)
+    assertEquals(SUB.isPrintableChar, false)
+    assertEquals(ESC.isPrintableChar, false)
+    assertEquals(FS.isPrintableChar, false)
+    assertEquals(GS.isPrintableChar, false)
+    assertEquals(RS.isPrintableChar, false)
+    assertEquals(US.isPrintableChar, false)
+    assertEquals(DEL.isControlChar, false)
+  }
+}

--- a/core/shared/src/test/scala/terminus/effect/AsciiSuite.scala
+++ b/core/shared/src/test/scala/terminus/effect/AsciiSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package terminus.effect
 
 import munit.FunSuite

--- a/docs/src/pages/examples.md
+++ b/docs/src/pages/examples.md
@@ -8,8 +8,8 @@ This example shows a simple UI you can easily build with Terminus. This is the k
 
 Here's the code for this example, running on the JVM backend. (The JS code is slightly different due to differences in how input is handled.)
 
-```scala
-import terminus.effect.Eof
+```scala 3
+import terminus.effect.{ Ascii, Eof }
 
 enum KeyCode {
   case Down
@@ -39,14 +39,15 @@ def write(selected: Int): Program[Unit] = {
   Terminal.flush()
 }
 
+@tailrec
 def read(): Program[KeyCode] = {
   Terminal.read() match {
     case Eof =>
       throw new Exception("Received an EOF")
     case char: Char =>
       char match {
-        case 10 | 13 => KeyCode.Enter
-        case '\u001b' =>
+        case Ascii.LF | Ascii.CR => KeyCode.Enter
+        case Ascii.ESC =>
           Terminal.read() match {
             // Normal mode
             case '[' =>
@@ -71,6 +72,7 @@ def read(): Program[KeyCode] = {
   }
 }
 
+@tailrec
 def loop(idx: Int): Program[Int] = {
   write(idx)
   read() match {


### PR DESCRIPTION
I went and grabbed all of the Ascii control characters from [here](https://www.ascii-code.com/) and put them in an object separate from the `AnsiCodes`. I'm happy to change all the identifiers to lowercase, however most places I see Ascii control characters referenced, they are always uppercase. I thought they would be more recognizable as upper case.

I also added some ascii based extension methods on `Char`. In particular, I could use an easy way to tell if there is a printable character so I can echo it in raw mode and explicitly handle control characters.

I went ahead and updated the examples to match.