### PR TITLE
Enabling terminal dimension feature

### DIFF
--- a/core/jvm/src/main/scala/terminus/JLineTerminal.scala
+++ b/core/jvm/src/main/scala/terminus/JLineTerminal.scala
@@ -16,10 +16,12 @@
 
 package terminus
 
+import org.jline.terminal.Size
 import org.jline.terminal.Terminal as JTerminal
 import org.jline.terminal.TerminalBuilder
 import org.jline.utils.InfoCmp.Capability
 import terminus.effect.Eof
+import terminus.effect.TerminalDimensions
 
 class JLineTerminal(terminal: JTerminal) extends Terminal {
   private val reader = terminal.reader()
@@ -47,6 +49,14 @@ class JLineTerminal(terminal: JTerminal) extends Terminal {
     }
   }
 
+  def getDimensions: effect.TerminalDimensions = {
+    val size = terminal.getSize
+    TerminalDimensions(size.getColumns, size.getRows)
+  }
+
+  def setDimensions(dimensions: TerminalDimensions): Unit =
+    terminal.setSize(Size(dimensions.noOfColumns, dimensions.noOfRows))
+
   def application[A](f: Terminal ?=> A): A = {
     try {
       terminal.puts(Capability.keypad_xmit)
@@ -73,6 +83,7 @@ object JLineTerminal
     extends Color,
       Cursor,
       Format,
+      Dimensions,
       Erase,
       AlternateScreenMode,
       ApplicationMode,

--- a/core/jvm/src/test/scala/terminus/effect/DimensionsSuite.scala
+++ b/core/jvm/src/test/scala/terminus/effect/DimensionsSuite.scala
@@ -14,30 +14,22 @@
  * limitations under the License.
  */
 
-package terminus
+package terminus.effect
 
-trait Terminal
-    extends effect.Color[Terminal],
-      effect.Cursor,
-      effect.Format[Terminal],
-      effect.Dimensions,
-      effect.Erase,
-      effect.AlternateScreenMode[Terminal],
-      effect.ApplicationMode[Terminal],
-      effect.RawMode[Terminal],
-      effect.Reader,
-      effect.Writer
-type Program[A] = Terminal ?=> A
+import munit.FunSuite
+import terminus.JLineTerminal
 
-object Terminal
-    extends Color,
-      Cursor,
-      Format,
-      Dimensions,
-      AlternateScreenMode,
-      ApplicationMode,
-      RawMode,
-      Reader,
-      Writer {
-  export JLineTerminal.*
+class DimensionsSuite extends FunSuite {
+
+  test("Should set and get the dimensions of the current terminal size") {
+
+    val userInputDimensions = TerminalDimensions(50, 50)
+
+    val outputDimensions = JLineTerminal.run {
+      JLineTerminal.dimensions.set(userInputDimensions)
+      JLineTerminal.dimensions.get
+    }
+
+    assertEquals(outputDimensions, userInputDimensions)
+  }
 }

--- a/core/shared/src/main/scala/terminus/Dimensions.scala
+++ b/core/shared/src/main/scala/terminus/Dimensions.scala
@@ -16,28 +16,17 @@
 
 package terminus
 
-trait Terminal
-    extends effect.Color[Terminal],
-      effect.Cursor,
-      effect.Format[Terminal],
-      effect.Dimensions,
-      effect.Erase,
-      effect.AlternateScreenMode[Terminal],
-      effect.ApplicationMode[Terminal],
-      effect.RawMode[Terminal],
-      effect.Reader,
-      effect.Writer
-type Program[A] = Terminal ?=> A
+import terminus.effect.TerminalDimensions
 
-object Terminal
-    extends Color,
-      Cursor,
-      Format,
-      Dimensions,
-      AlternateScreenMode,
-      ApplicationMode,
-      RawMode,
-      Reader,
-      Writer {
-  export JLineTerminal.*
+/** Functionalities related to the dimensions of the terminal */
+trait Dimensions {
+  object dimensions {
+    def get: effect.Dimensions ?=> TerminalDimensions = effect ?=>
+      effect.getDimensions
+
+    def set[F <: effect.Effect](
+        dimensions: TerminalDimensions
+    ): (F & effect.Dimensions) ?=> Unit =
+      effect ?=> effect.setDimensions(dimensions)
+  }
 }

--- a/core/shared/src/main/scala/terminus/effect/Dimensions.scala
+++ b/core/shared/src/main/scala/terminus/effect/Dimensions.scala
@@ -14,30 +14,19 @@
  * limitations under the License.
  */
 
-package terminus
+package terminus.effect
 
-trait Terminal
-    extends effect.Color[Terminal],
-      effect.Cursor,
-      effect.Format[Terminal],
-      effect.Dimensions,
-      effect.Erase,
-      effect.AlternateScreenMode[Terminal],
-      effect.ApplicationMode[Terminal],
-      effect.RawMode[Terminal],
-      effect.Reader,
-      effect.Writer
-type Program[A] = Terminal ?=> A
+//import org.jline.terminal.Size
 
-object Terminal
-    extends Color,
-      Cursor,
-      Format,
-      Dimensions,
-      AlternateScreenMode,
-      ApplicationMode,
-      RawMode,
-      Reader,
-      Writer {
-  export JLineTerminal.*
+/** Functionalities related to the dimensions of the terminal */
+trait Dimensions extends Effect {
+  def getDimensions: TerminalDimensions
+  def setDimensions(dimensions: TerminalDimensions): Unit
 }
+
+final case class TerminalDimensions(noOfColumns: Int, noOfRows: Int)
+
+//object TerminalDimensions {
+//  extension (size: Size) def fromJLineSize: TerminalDimensions =
+//    TerminalDimensions(size.getColumns, size.getRows)
+//}


### PR DESCRIPTION
This will only work for terminals that support `JLine`. 

I added the set terminal size feature to enable testing for this issue. 