### PR TITLE
Add cursor left and right movement commands. Fixes #26.

### DIFF
--- a/core/shared/src/main/scala/terminus/Cursor.scala
+++ b/core/shared/src/main/scala/terminus/Cursor.scala
@@ -46,12 +46,14 @@ trait Cursor {
     /** Move the cursor down the given number of rows. Defaults to 1 row. */
     def down(lines: Int = 1): effect.Cursor ?=> Unit =
       effect ?=> effect.cursor.down(lines)
-      
-    /** Move the cursor right the given number of columns. Defaults to 1 column. */
+
+    /** Move the cursor right the given number of columns. Defaults to 1 column.
+      */
     def right(columns: Int = 1): effect.Cursor ?=> Unit =
       effect ?=> effect.cursor.right(columns)
-      
-    /** Move the cursor left the given number of columns. Defaults to 1 column. */
+
+    /** Move the cursor left the given number of columns. Defaults to 1 column.
+      */
     def left(columns: Int = 1): effect.Cursor ?=> Unit =
       effect ?=> effect.cursor.left(columns)
   }

--- a/core/shared/src/main/scala/terminus/Cursor.scala
+++ b/core/shared/src/main/scala/terminus/Cursor.scala
@@ -46,5 +46,13 @@ trait Cursor {
     /** Move the cursor down the given number of rows. Defaults to 1 row. */
     def down(lines: Int = 1): effect.Cursor ?=> Unit =
       effect ?=> effect.cursor.down(lines)
+      
+    /** Move the cursor right the given number of columns. Defaults to 1 column. */
+    def right(columns: Int = 1): effect.Cursor ?=> Unit =
+      effect ?=> effect.cursor.right(columns)
+      
+    /** Move the cursor left the given number of columns. Defaults to 1 column. */
+    def left(columns: Int = 1): effect.Cursor ?=> Unit =
+      effect ?=> effect.cursor.left(columns)
   }
 }

--- a/core/shared/src/main/scala/terminus/effect/Cursor.scala
+++ b/core/shared/src/main/scala/terminus/effect/Cursor.scala
@@ -52,5 +52,13 @@ trait Cursor extends Writer {
     /** Move the cursor down the given number of rows. Defaults to 1 row. */
     def down(lines: Int = 1): Unit =
       write(AnsiCodes.cursor.down(lines))
+      
+    /** Move the cursor right the given number of columns. Defaults to 1 column. */
+    def right(columns: Int = 1): Unit =
+      write(AnsiCodes.cursor.forward(columns))
+      
+    /** Move the cursor left the given number of columns. Defaults to 1 column. */
+    def left(columns: Int = 1): Unit =
+      write(AnsiCodes.cursor.backward(columns))
   }
 }

--- a/core/shared/src/main/scala/terminus/effect/Cursor.scala
+++ b/core/shared/src/main/scala/terminus/effect/Cursor.scala
@@ -52,11 +52,11 @@ trait Cursor extends Writer {
     /** Move the cursor down the given number of rows. Defaults to 1 row. */
     def down(lines: Int = 1): Unit =
       write(AnsiCodes.cursor.down(lines))
-      
+
     /** Move the cursor right the given number of columns. Defaults to 1 column. */
     def right(columns: Int = 1): Unit =
       write(AnsiCodes.cursor.forward(columns))
-      
+
     /** Move the cursor left the given number of columns. Defaults to 1 column. */
     def left(columns: Int = 1): Unit =
       write(AnsiCodes.cursor.backward(columns))

--- a/core/shared/src/main/scala/terminus/effect/Cursor.scala
+++ b/core/shared/src/main/scala/terminus/effect/Cursor.scala
@@ -53,11 +53,13 @@ trait Cursor extends Writer {
     def down(lines: Int = 1): Unit =
       write(AnsiCodes.cursor.down(lines))
 
-    /** Move the cursor right the given number of columns. Defaults to 1 column. */
+    /** Move the cursor right the given number of columns. Defaults to 1 column.
+      */
     def right(columns: Int = 1): Unit =
       write(AnsiCodes.cursor.forward(columns))
 
-    /** Move the cursor left the given number of columns. Defaults to 1 column. */
+    /** Move the cursor left the given number of columns. Defaults to 1 column.
+      */
     def left(columns: Int = 1): Unit =
       write(AnsiCodes.cursor.backward(columns))
   }

--- a/core/shared/src/test/scala/terminus/effect/CursorSuite.scala
+++ b/core/shared/src/test/scala/terminus/effect/CursorSuite.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Creative Scala
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package terminus.effect
+
+import munit.FunSuite
+
+class CursorSuite extends FunSuite {
+  
+  // Test implementation for Writer trait to record what's written
+  trait TestWriter extends Writer {
+    var written: String = ""
+    def write(str: String): Unit = written += str
+    def write(char: Char): Unit = written += char
+    def flush(): Unit = ()
+    def clear(): Unit = written = ""
+  }
+  
+  // Test implementation for Cursor that uses our TestWriter
+  class TestCursor extends Cursor with TestWriter
+
+  test("cursor.left moves cursor left by default 1 column") {
+    val cursor = new TestCursor()
+    cursor.cursor.left()
+    assertEquals(cursor.written, s"${Ascii.ESC}[1D")
+  }
+  
+  test("cursor.left moves cursor left by specified columns") {
+    val cursor = new TestCursor()
+    cursor.cursor.left(5)
+    assertEquals(cursor.written, s"${Ascii.ESC}[5D")
+  }
+  
+  test("cursor.right moves cursor right by default 1 column") {
+    val cursor = new TestCursor()
+    cursor.cursor.right()
+    assertEquals(cursor.written, s"${Ascii.ESC}[1C")
+  }
+  
+  test("cursor.right moves cursor right by specified columns") {
+    val cursor = new TestCursor()
+    cursor.cursor.right(3)
+    assertEquals(cursor.written, s"${Ascii.ESC}[3C")
+  }
+  
+  test("all cursor movement methods emit correct ANSI codes") {
+    val cursor = new TestCursor()
+    
+    cursor.clear()
+    cursor.cursor.up()
+    assertEquals(cursor.written, s"${Ascii.ESC}[1A")
+    
+    cursor.clear()
+    cursor.cursor.down()
+    assertEquals(cursor.written, s"${Ascii.ESC}[1B")
+    
+    cursor.clear()
+    cursor.cursor.right()
+    assertEquals(cursor.written, s"${Ascii.ESC}[1C")
+    
+    cursor.clear()
+    cursor.cursor.left()
+    assertEquals(cursor.written, s"${Ascii.ESC}[1D")
+  }
+}

--- a/core/shared/src/test/scala/terminus/effect/CursorSuite.scala
+++ b/core/shared/src/test/scala/terminus/effect/CursorSuite.scala
@@ -26,40 +26,40 @@ class CursorSuite extends FunSuite {
     terminal.cursor.left()
     assertEquals(terminal.result(), s"${Ascii.ESC}[1D")
   }
-  
+
   test("cursor.left moves cursor left by specified columns") {
     val terminal = new StringBuilderTerminal()
     terminal.cursor.left(5)
     assertEquals(terminal.result(), s"${Ascii.ESC}[5D")
   }
-  
+
   test("cursor.right moves cursor right by default 1 column") {
     val terminal = new StringBuilderTerminal()
     terminal.cursor.right()
     assertEquals(terminal.result(), s"${Ascii.ESC}[1C")
   }
-  
+
   test("cursor.right moves cursor right by specified columns") {
     val terminal = new StringBuilderTerminal()
     terminal.cursor.right(3)
     assertEquals(terminal.result(), s"${Ascii.ESC}[3C")
   }
-  
+
   test("all cursor movement methods emit correct ANSI codes") {
     val terminal = new StringBuilderTerminal()
-    
+
     terminal.cursor.up()
     val up = terminal.result()
     assertEquals(up, s"${Ascii.ESC}[1A")
-    
+
     terminal.cursor.down()
     val down = terminal.result()
     assertEquals(down, s"${Ascii.ESC}[1B")
-    
+
     terminal.cursor.right()
     val right = terminal.result()
     assertEquals(right, s"${Ascii.ESC}[1C")
-    
+
     terminal.cursor.left()
     val left = terminal.result()
     assertEquals(left, s"${Ascii.ESC}[1D")

--- a/core/shared/src/test/scala/terminus/effect/CursorSuite.scala
+++ b/core/shared/src/test/scala/terminus/effect/CursorSuite.scala
@@ -17,62 +17,51 @@
 package terminus.effect
 
 import munit.FunSuite
+import terminus.StringBuilderTerminal
 
 class CursorSuite extends FunSuite {
-  
-  // Test implementation for Writer trait to record what's written
-  trait TestWriter extends Writer {
-    var written: String = ""
-    def write(str: String): Unit = written += str
-    def write(char: Char): Unit = written += char
-    def flush(): Unit = ()
-    def clear(): Unit = written = ""
-  }
-  
-  // Test implementation for Cursor that uses our TestWriter
-  class TestCursor extends Cursor with TestWriter
 
   test("cursor.left moves cursor left by default 1 column") {
-    val cursor = new TestCursor()
-    cursor.cursor.left()
-    assertEquals(cursor.written, s"${Ascii.ESC}[1D")
+    val terminal = new StringBuilderTerminal()
+    terminal.cursor.left()
+    assertEquals(terminal.result(), s"${Ascii.ESC}[1D")
   }
   
   test("cursor.left moves cursor left by specified columns") {
-    val cursor = new TestCursor()
-    cursor.cursor.left(5)
-    assertEquals(cursor.written, s"${Ascii.ESC}[5D")
+    val terminal = new StringBuilderTerminal()
+    terminal.cursor.left(5)
+    assertEquals(terminal.result(), s"${Ascii.ESC}[5D")
   }
   
   test("cursor.right moves cursor right by default 1 column") {
-    val cursor = new TestCursor()
-    cursor.cursor.right()
-    assertEquals(cursor.written, s"${Ascii.ESC}[1C")
+    val terminal = new StringBuilderTerminal()
+    terminal.cursor.right()
+    assertEquals(terminal.result(), s"${Ascii.ESC}[1C")
   }
   
   test("cursor.right moves cursor right by specified columns") {
-    val cursor = new TestCursor()
-    cursor.cursor.right(3)
-    assertEquals(cursor.written, s"${Ascii.ESC}[3C")
+    val terminal = new StringBuilderTerminal()
+    terminal.cursor.right(3)
+    assertEquals(terminal.result(), s"${Ascii.ESC}[3C")
   }
   
   test("all cursor movement methods emit correct ANSI codes") {
-    val cursor = new TestCursor()
+    val terminal = new StringBuilderTerminal()
     
-    cursor.clear()
-    cursor.cursor.up()
-    assertEquals(cursor.written, s"${Ascii.ESC}[1A")
+    terminal.cursor.up()
+    val up = terminal.result()
+    assertEquals(up, s"${Ascii.ESC}[1A")
     
-    cursor.clear()
-    cursor.cursor.down()
-    assertEquals(cursor.written, s"${Ascii.ESC}[1B")
+    terminal.cursor.down()
+    val down = terminal.result()
+    assertEquals(down, s"${Ascii.ESC}[1B")
     
-    cursor.clear()
-    cursor.cursor.right()
-    assertEquals(cursor.written, s"${Ascii.ESC}[1C")
+    terminal.cursor.right()
+    val right = terminal.result()
+    assertEquals(right, s"${Ascii.ESC}[1C")
     
-    cursor.clear()
-    cursor.cursor.left()
-    assertEquals(cursor.written, s"${Ascii.ESC}[1D")
+    terminal.cursor.left()
+    val left = terminal.result()
+    assertEquals(left, s"${Ascii.ESC}[1D")
   }
 }


### PR DESCRIPTION
# Add cursor left and right movement commands

## Description
This PR implements the functionality requested in issue #26 to add commands for moving the cursor left and right using the ANSI escape codes `ESC[cC` and `ESC[cD` (where `c` is the number of columns).

## Changes Made
- Added `right(columns: Int = 1)` method to `terminus.effect.Cursor` that uses `AnsiCodes.cursor.forward` to generate `ESC[cC`
- Added `left(columns: Int = 1)` method to `terminus.effect.Cursor` that uses `AnsiCodes.cursor.backward` to generate `ESC[cD`
- Added corresponding methods to the public `terminus.Cursor` trait that delegate to the new methods in the effect layer
- Created comprehensive test suite `CursorSuite.scala` to verify the correct ANSI codes are generated

## Testing
Added unit tests in `CursorSuite` that verify:
- Default movement of 1 column for both left and right
- Custom column counts for both directions
- Correct ANSI escape sequences are generated for each operation

All tests pass successfully, confirming that the implementation works as expected.
![Screenshot 2025-04-30 174317](https://github.com/user-attachments/assets/622c68da-2421-4820-9f97-809ec23c5e5a)
## Related Issues
Fixes #26

